### PR TITLE
Device enrollment: per-user credentials over one-time email codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +467,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +503,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.1.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -679,6 +724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -1367,6 +1413,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,6 +1755,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,6 +1951,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,6 +2120,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "cbindgen",
+ "chacha20poly1305",
  "chrono",
  "clap 4.5.38",
  "colored",
@@ -2059,6 +2132,7 @@ dependencies = [
  "json-patch",
  "log",
  "phoenix_channels_client",
+ "rand",
  "ratatui",
  "replicant-core",
  "serde",
@@ -2066,6 +2140,7 @@ dependencies = [
  "serial_test",
  "sha2",
  "sqlx",
+ "tempfile",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -3318,6 +3393,16 @@ dependencies = [
  "uniffi_meta",
  "uniffi_testing",
  "weedle2",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,7 +115,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -176,6 +161,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-compat"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,12 +210,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8ab6b55fe97976e46f91ddbed8d147d966475dc29b2032757ba47e02376fbc3"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -287,21 +288,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -467,6 +453,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,7 +466,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -484,7 +487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -663,6 +666,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,7 +736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -733,6 +745,24 @@ name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"
@@ -1061,8 +1091,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1073,15 +1105,23 @@ checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.2.0",
  "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
+name = "getrandom"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "glob"
@@ -1098,6 +1138,25 @@ dependencies = [
  "log",
  "plain",
  "scroll",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.9.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1146,6 +1205,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1228,13 +1293,15 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1243,6 +1310,23 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -1251,14 +1335,21 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1422,6 +1513,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1566,6 +1663,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,15 +1722,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "mio"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,13 +1735,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1698,7 +1792,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -1734,12 +1828,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.7"
+name = "num_cpus"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "memchr",
+ "hermit-abi 0.5.2",
+ "libc",
 ]
 
 [[package]]
@@ -1856,7 +1951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1956,7 +2051,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -2004,6 +2099,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.5.9",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.12",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.5.9",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,6 +2170,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,7 +2183,18 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2036,7 +2204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2046,6 +2214,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2132,9 +2315,10 @@ dependencies = [
  "json-patch",
  "log",
  "phoenix_channels_client",
- "rand",
+ "rand 0.8.5",
  "ratatui",
  "replicant-core",
+ "reqwest",
  "serde",
  "serde_json",
  "serial_test",
@@ -2147,6 +2331,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -2184,6 +2369,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2210,7 +2433,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -2218,10 +2441,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.24"
+name = "rustc-hash"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"
@@ -2256,6 +2479,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2471,7 +2695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2488,7 +2712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2550,7 +2774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2591,6 +2815,16 @@ checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2731,7 +2965,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "sha1",
@@ -2771,7 +3005,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
@@ -2910,6 +3144,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -3030,27 +3267,26 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
- "mio 1.0.4",
+ "mio 1.2.1",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.4",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3064,6 +3300,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
  "tokio",
 ]
 
@@ -3093,6 +3339,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,6 +3374,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -3192,6 +3469,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3204,7 +3487,7 @@ dependencies = [
  "httparse",
  "log",
  "native-tls",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
@@ -3482,6 +3765,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3529,6 +3821,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3558,6 +3863,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3849,6 +4174,29 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/replicant-client/Cargo.toml
+++ b/replicant-client/Cargo.toml
@@ -20,8 +20,11 @@ sha2 = "0.10"
 hex = "0.4"
 url = "2.5"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+chacha20poly1305 = "0.10"
+rand = "0.8"
 
 [dev-dependencies]
+tempfile = "3"
 clap = { version = "4.4", features = ["derive", "env"] }
 dialoguer = "0.11"
 colored = "2.1"

--- a/replicant-client/Cargo.toml
+++ b/replicant-client/Cargo.toml
@@ -22,9 +22,11 @@ url = "2.5"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 chacha20poly1305 = "0.10"
 rand = "0.8"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 [dev-dependencies]
 tempfile = "3"
+wiremock = "0.6"
 clap = { version = "4.4", features = ["derive", "env"] }
 dialoguer = "0.11"
 colored = "2.1"

--- a/replicant-client/include/replicant.h
+++ b/replicant-client/include/replicant.h
@@ -211,7 +211,8 @@ struct Replicant *replicant_create(const char *database_url,
                                    const char *server_url,
                                    const char *email,
                                    const char *api_key,
-                                   const char *api_secret);
+                                   const char *api_secret,
+                                   const char *user_id);
 
 /**
  * Destroy a sync engine instance and free memory
@@ -621,38 +622,55 @@ enum ReplicantSyncResult replicant_enroll_request(const char *base_url, const ch
 
 /**
  * Exchanges an enrollment token for a per-user credential. On success writes
- * the api_key and secret into the out buffers (each must hold >= 69 bytes).
+ * the api_key, secret, and canonical user id (36-char UUID string) into the
+ * out buffers; each `*_cap` is the writable size of its buffer in bytes and
+ * the call fails (without overflowing) when a value does not fit.
  *
  * # Safety
- * All string pointers must be valid, non-null C strings; `out_api_key` and
- * `out_secret` must each point to a writable buffer of at least 69 bytes.
+ * All string pointers must be valid, non-null C strings; each out pointer
+ * must reference a writable buffer of at least its stated capacity.
  */
 enum ReplicantSyncResult replicant_enroll_claim(const char *base_url,
                                                 const char *email,
                                                 const char *token,
                                                 char *out_api_key,
-                                                char *out_secret);
+                                                uintptr_t api_key_cap,
+                                                char *out_secret,
+                                                uintptr_t secret_cap,
+                                                char *out_user_id,
+                                                uintptr_t user_id_cap);
 
 /**
- * Loads stored credentials from `data_dir`. Returns Success and fills the out
- * buffers, or ErrorDatabase if none are stored / unreadable.
+ * Loads stored credentials from `data_dir`. Returns Success and fills the
+ * out buffers (api_key, secret, canonical user id), or ErrorDatabase if none
+ * are stored / unreadable. Each `*_cap` is the writable size of its buffer;
+ * the call fails (without overflowing) when a value does not fit.
  *
  * # Safety
- * `data_dir` must be a valid, non-null C string; out buffers each >= 69 bytes.
+ * `data_dir` must be a valid, non-null C string; each out pointer must
+ * reference a writable buffer of at least its stated capacity.
  */
 enum ReplicantSyncResult replicant_load_credentials(const char *data_dir,
                                                     char *out_api_key,
-                                                    char *out_secret);
+                                                    uintptr_t api_key_cap,
+                                                    char *out_secret,
+                                                    uintptr_t secret_cap,
+                                                    char *out_user_id,
+                                                    uintptr_t user_id_cap);
 
 /**
- * Stores credentials to `data_dir` (encrypted at rest).
+ * Stores credentials to `data_dir` (encrypted at rest). `user_id` is the
+ * canonical id delivered by enrollment claim (36-char UUID string); a nil or
+ * unparseable id is rejected — credentials are never stored without a real
+ * identity.
  *
  * # Safety
  * All pointers must be valid, non-null C strings.
  */
 enum ReplicantSyncResult replicant_store_credentials(const char *data_dir,
                                                      const char *api_key,
-                                                     const char *secret);
+                                                     const char *secret,
+                                                     const char *user_id);
 
 /**
  * Clears any stored credentials in `data_dir`.

--- a/replicant-client/include/replicant.h
+++ b/replicant-client/include/replicant.h
@@ -611,6 +611,58 @@ enum ReplicantSyncResult replicant_search_documents(struct Replicant *engine,
 enum ReplicantSyncResult replicant_rebuild_search_index(struct Replicant *engine);
 
 /**
+ * Requests an enrollment token be emailed to `email`. Standalone HTTP call
+ * (no engine handle); spins a short-lived runtime to drive the async request.
+ *
+ * # Safety
+ * `base_url` and `email` must be valid, non-null C strings.
+ */
+enum ReplicantSyncResult replicant_enroll_request(const char *base_url, const char *email);
+
+/**
+ * Exchanges an enrollment token for a per-user credential. On success writes
+ * the api_key and secret into the out buffers (each must hold >= 69 bytes).
+ *
+ * # Safety
+ * All string pointers must be valid, non-null C strings; `out_api_key` and
+ * `out_secret` must each point to a writable buffer of at least 69 bytes.
+ */
+enum ReplicantSyncResult replicant_enroll_claim(const char *base_url,
+                                                const char *email,
+                                                const char *token,
+                                                char *out_api_key,
+                                                char *out_secret);
+
+/**
+ * Loads stored credentials from `data_dir`. Returns Success and fills the out
+ * buffers, or ErrorDatabase if none are stored / unreadable.
+ *
+ * # Safety
+ * `data_dir` must be a valid, non-null C string; out buffers each >= 69 bytes.
+ */
+enum ReplicantSyncResult replicant_load_credentials(const char *data_dir,
+                                                    char *out_api_key,
+                                                    char *out_secret);
+
+/**
+ * Stores credentials to `data_dir` (encrypted at rest).
+ *
+ * # Safety
+ * All pointers must be valid, non-null C strings.
+ */
+enum ReplicantSyncResult replicant_store_credentials(const char *data_dir,
+                                                     const char *api_key,
+                                                     const char *secret);
+
+/**
+ * Clears any stored credentials in `data_dir`.
+ *
+ * # Safety
+ * `data_dir` must be a valid, non-null C string.
+ */
+enum ReplicantSyncResult replicant_clear_credentials(const char *data_dir);
+
+/**
  * Trigger a test event (for development/testing purposes)
  *
  * # Arguments

--- a/replicant-client/include/replicant.hpp
+++ b/replicant-client/include/replicant.hpp
@@ -416,4 +416,67 @@ public:
     Client& operator=(Client&&) = default;
 };
 
+//==============================================================================
+// Enrollment + credential storage
+//
+// Standalone helpers (no Client instance): a device exchanges an emailed,
+// one-time token for its own per-user credential, stored encrypted at rest.
+
+struct Credentials
+{
+    std::string api_key;
+    std::string secret;
+};
+
+/** Requests an enrollment token be emailed to `email`. Returns true if the
+    server accepted the request (HTTP 202). */
+inline bool request_enrollment(const std::string& base_url, const std::string& email)
+{
+    return replicant_enroll_request(base_url.c_str(), email.c_str()) == Success;
+}
+
+/** Exchanges a one-time token for a per-user credential. On success fills `out`
+    and returns true; returns false if the token is invalid/expired or the
+    request failed. */
+inline bool claim_enrollment(const std::string& base_url, const std::string& email,
+                             const std::string& token, Credentials& out)
+{
+    char api_key[128] = {0};
+    char secret[128] = {0};
+    if (replicant_enroll_claim(base_url.c_str(), email.c_str(), token.c_str(), api_key, secret)
+        != Success)
+        return false;
+
+    out.api_key = api_key;
+    out.secret = secret;
+    return true;
+}
+
+/** Loads the stored credential from `data_dir`. On success fills `out` and
+    returns true; returns false if none is stored / it is unreadable. */
+inline bool load_credentials(const std::string& data_dir, Credentials& out)
+{
+    char api_key[128] = {0};
+    char secret[128] = {0};
+    if (replicant_load_credentials(data_dir.c_str(), api_key, secret) != Success)
+        return false;
+
+    out.api_key = api_key;
+    out.secret = secret;
+    return true;
+}
+
+/** Stores a credential in `data_dir`, encrypted at rest. Returns true on success. */
+inline bool store_credentials(const std::string& data_dir, const Credentials& creds)
+{
+    return replicant_store_credentials(data_dir.c_str(), creds.api_key.c_str(),
+                                       creds.secret.c_str()) == Success;
+}
+
+/** Clears any stored credential in `data_dir`. Returns true on success. */
+inline bool clear_credentials(const std::string& data_dir)
+{
+    return replicant_clear_credentials(data_dir.c_str()) == Success;
+}
+
 } // namespace replicant

--- a/replicant-client/include/replicant.hpp
+++ b/replicant-client/include/replicant.hpp
@@ -72,20 +72,26 @@ public:
      * @param email User email address for identification
      * @param api_key Application API key (rpa_ prefix)
      * @param api_secret Application API secret (rps_ prefix)
+     * @param user_id Canonical user id from stored credentials (UUID string);
+     *                empty when no enrolled identity exists (offline/local-only).
+     *                Adoption of this id happens during construction, before
+     *                any sync connection.
      * @throws SyncException if creation fails
      */
     Client(const std::string& database_url,
            const std::string& server_url,
            const std::string& email,
            const std::string& api_key,
-           const std::string& api_secret)
+           const std::string& api_secret,
+           const std::string& user_id = {})
     {
         Replicant* raw_handle = replicant_create(
             database_url.c_str(),
             server_url.c_str(),
             email.c_str(),
             api_key.c_str(),
-            api_secret.c_str()
+            api_secret.c_str(),
+            user_id.empty() ? nullptr : user_id.c_str()
         );
 
         if (!raw_handle)
@@ -368,6 +374,22 @@ public:
     }
 
     /**
+     * Register a callback for identity changes (provisional id adopted into
+     * the canonical one). Consumers caching the user id must refresh it —
+     * and any owner-filtered views — when this fires.
+     *
+     * @param callback Function to call with (event_type, old_user_id,
+     *                 new_user_id, email, context)
+     * @param context User-defined context pointer passed to callback
+     * @throws SyncException if registration fails
+     */
+    void register_identity_callback(IdentityEventCallback callback, void* context)
+    {
+        SyncResult result = replicant_register_identity_callback(handle.get(), callback, context);
+        check_result(result);
+    }
+
+    /**
      * Register a callback for connection events (Lost, Attempted, Succeeded)
      *
      * @param callback Function to call for connection events
@@ -426,6 +448,7 @@ struct Credentials
 {
     std::string api_key;
     std::string secret;
+    std::string user_id; ///< Canonical user id (UUID) delivered by enrollment claim.
 };
 
 /** Requests an enrollment token be emailed to `email`. Returns true if the
@@ -436,19 +459,22 @@ inline bool request_enrollment(const std::string& base_url, const std::string& e
 }
 
 /** Exchanges a one-time token for a per-user credential. On success fills `out`
-    and returns true; returns false if the token is invalid/expired or the
-    request failed. */
+    (including the canonical user id) and returns true; returns false if the
+    token is invalid/expired or the request failed. */
 inline bool claim_enrollment(const std::string& base_url, const std::string& email,
                              const std::string& token, Credentials& out)
 {
-    char api_key[128] = {0};
-    char secret[128] = {0};
-    if (replicant_enroll_claim(base_url.c_str(), email.c_str(), token.c_str(), api_key, secret)
+    char api_key[129] = {0};
+    char secret[129] = {0};
+    char user_id[37] = {0};
+    if (replicant_enroll_claim(base_url.c_str(), email.c_str(), token.c_str(), api_key,
+                               sizeof(api_key), secret, sizeof(secret), user_id, sizeof(user_id))
         != Success)
         return false;
 
     out.api_key = api_key;
     out.secret = secret;
+    out.user_id = user_id;
     return true;
 }
 
@@ -456,21 +482,27 @@ inline bool claim_enrollment(const std::string& base_url, const std::string& ema
     returns true; returns false if none is stored / it is unreadable. */
 inline bool load_credentials(const std::string& data_dir, Credentials& out)
 {
-    char api_key[128] = {0};
-    char secret[128] = {0};
-    if (replicant_load_credentials(data_dir.c_str(), api_key, secret) != Success)
+    char api_key[129] = {0};
+    char secret[129] = {0};
+    char user_id[37] = {0};
+    if (replicant_load_credentials(data_dir.c_str(), api_key, sizeof(api_key), secret,
+                                   sizeof(secret), user_id, sizeof(user_id))
+        != Success)
         return false;
 
     out.api_key = api_key;
     out.secret = secret;
+    out.user_id = user_id;
     return true;
 }
 
-/** Stores a credential in `data_dir`, encrypted at rest. Returns true on success. */
+/** Stores a credential in `data_dir`, encrypted at rest. `creds.user_id` must
+    be a real (non-nil) UUID string. Returns true on success. */
 inline bool store_credentials(const std::string& data_dir, const Credentials& creds)
 {
     return replicant_store_credentials(data_dir.c_str(), creds.api_key.c_str(),
-                                       creds.secret.c_str()) == Success;
+                                       creds.secret.c_str(), creds.user_id.c_str())
+           == Success;
 }
 
 /** Clears any stored credential in `data_dir`. Returns true on success. */

--- a/replicant-client/src/enrollment.rs
+++ b/replicant-client/src/enrollment.rs
@@ -1,0 +1,93 @@
+//! HTTP client for the plugin-initiated enrollment flow.
+use crate::secret_store::Credentials;
+
+#[derive(Debug, thiserror::Error)]
+pub enum EnrollError {
+    #[error("invalid or expired token")]
+    InvalidToken,
+    #[error("enrollment request failed: {0}")]
+    Http(String),
+}
+
+pub async fn request(base_url: &str, email: &str) -> Result<(), EnrollError> {
+    let resp = reqwest::Client::new()
+        .post(format!("{base_url}/api/enroll/request"))
+        .json(&serde_json::json!({ "email": email }))
+        .send()
+        .await
+        .map_err(|e| EnrollError::Http(e.to_string()))?;
+
+    if resp.status().as_u16() == 202 {
+        Ok(())
+    } else {
+        Err(EnrollError::Http(format!("status {}", resp.status())))
+    }
+}
+
+pub async fn claim(base_url: &str, email: &str, token: &str) -> Result<Credentials, EnrollError> {
+    let resp = reqwest::Client::new()
+        .post(format!("{base_url}/api/enroll/claim"))
+        .json(&serde_json::json!({ "email": email, "token": token }))
+        .send()
+        .await
+        .map_err(|e| EnrollError::Http(e.to_string()))?;
+
+    match resp.status().as_u16() {
+        200 => resp
+            .json::<Credentials>()
+            .await
+            .map_err(|e| EnrollError::Http(e.to_string())),
+        401 => Err(EnrollError::InvalidToken),
+        s => Err(EnrollError::Http(format!("status {s}"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn request_treats_202_as_ok() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/enroll/request"))
+            .respond_with(ResponseTemplate::new(202))
+            .mount(&server)
+            .await;
+
+        assert!(request(&server.uri(), "a@b.com").await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn claim_returns_credentials_on_200() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/enroll/claim"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"api_key":"rpa_x","secret":"rps_y"})),
+            )
+            .mount(&server)
+            .await;
+
+        let creds = claim(&server.uri(), "a@b.com", "TOK").await.unwrap();
+        assert_eq!(creds.api_key, "rpa_x");
+    }
+
+    #[tokio::test]
+    async fn claim_maps_401_to_invalid_token() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/enroll/claim"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+
+        assert!(matches!(
+            claim(&server.uri(), "a@b.com", "TOK").await,
+            Err(EnrollError::InvalidToken)
+        ));
+    }
+}

--- a/replicant-client/src/enrollment.rs
+++ b/replicant-client/src/enrollment.rs
@@ -1,5 +1,6 @@
 //! HTTP client for the plugin-initiated enrollment flow.
 use crate::secret_store::Credentials;
+use std::time::Duration;
 
 #[derive(Debug, thiserror::Error)]
 pub enum EnrollError {
@@ -9,9 +10,13 @@ pub enum EnrollError {
     Http(String),
     #[error("enrollment response invalid or incomplete")]
     InvalidResponse,
+    #[error("insecure base_url: https:// is required (localhost/127.0.0.1 excepted)")]
+    InsecureUrl,
 }
 
 const MAX_CRED_LEN: usize = 128;
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 fn validate(creds: &Credentials) -> Result<(), EnrollError> {
     if creds.user_id.is_nil()
@@ -25,8 +30,44 @@ fn validate(creds: &Credentials) -> Result<(), EnrollError> {
     Ok(())
 }
 
+/// Requires `https://`, except `http://localhost` / `http://127.0.0.1`
+/// (any port) for tests and local dev.
+fn validate_url(base_url: &str) -> Result<(), EnrollError> {
+    if base_url.starts_with("https://") {
+        return Ok(());
+    }
+    if let Ok(parsed) = url::Url::parse(base_url) {
+        if parsed.scheme() == "http" {
+            if let Some(host) = parsed.host_str() {
+                if host == "localhost" || host == "127.0.0.1" {
+                    return Ok(());
+                }
+            }
+        }
+    }
+    Err(EnrollError::InsecureUrl)
+}
+
+fn build_client(connect_timeout: Duration, timeout: Duration) -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(connect_timeout)
+        .timeout(timeout)
+        .build()
+        .expect("reqwest client config is always valid")
+}
+
 pub async fn request(base_url: &str, email: &str) -> Result<(), EnrollError> {
-    let resp = reqwest::Client::new()
+    request_with_timeouts(base_url, email, CONNECT_TIMEOUT, REQUEST_TIMEOUT).await
+}
+
+async fn request_with_timeouts(
+    base_url: &str,
+    email: &str,
+    connect_timeout: Duration,
+    timeout: Duration,
+) -> Result<(), EnrollError> {
+    validate_url(base_url)?;
+    let resp = build_client(connect_timeout, timeout)
         .post(format!("{base_url}/api/enroll/request"))
         .json(&serde_json::json!({ "email": email }))
         .send()
@@ -41,7 +82,18 @@ pub async fn request(base_url: &str, email: &str) -> Result<(), EnrollError> {
 }
 
 pub async fn claim(base_url: &str, email: &str, token: &str) -> Result<Credentials, EnrollError> {
-    let resp = reqwest::Client::new()
+    claim_with_timeouts(base_url, email, token, CONNECT_TIMEOUT, REQUEST_TIMEOUT).await
+}
+
+async fn claim_with_timeouts(
+    base_url: &str,
+    email: &str,
+    token: &str,
+    connect_timeout: Duration,
+    timeout: Duration,
+) -> Result<Credentials, EnrollError> {
+    validate_url(base_url)?;
+    let resp = build_client(connect_timeout, timeout)
         .post(format!("{base_url}/api/enroll/claim"))
         .json(&serde_json::json!({ "email": email, "token": token }))
         .send()
@@ -204,6 +256,58 @@ mod tests {
             claim(&server.uri(), "a@b.com", "TOK").await,
             Err(EnrollError::InvalidResponse)
         ));
+    }
+
+    #[tokio::test]
+    async fn claim_rejects_plain_http_base_url() {
+        // No wiremock server needed: rejection happens before any HTTP call.
+        assert!(matches!(
+            claim("http://example.com", "a@b.com", "TOK").await,
+            Err(EnrollError::InsecureUrl)
+        ));
+        assert!(matches!(
+            request("http://example.com", "a@b.com").await,
+            Err(EnrollError::InsecureUrl)
+        ));
+    }
+
+    #[tokio::test]
+    async fn claim_allows_localhost_and_127_0_0_1_over_http() {
+        // wiremock's server.uri() is http://127.0.0.1:<port>; the existing
+        // wiremock-backed tests above only pass because this is allowed.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/enroll/request"))
+            .respond_with(ResponseTemplate::new(202))
+            .mount(&server)
+            .await;
+        assert!(request(&server.uri(), "a@b.com").await.is_ok());
+
+        assert!(validate_url("http://localhost").is_ok());
+        assert!(validate_url("http://localhost:8080").is_ok());
+        assert!(validate_url("http://127.0.0.1:9999").is_ok());
+        assert!(validate_url("https://example.com").is_ok());
+    }
+
+    #[tokio::test]
+    async fn request_times_out() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/enroll/request"))
+            .respond_with(
+                ResponseTemplate::new(202).set_delay(std::time::Duration::from_millis(300)),
+            )
+            .mount(&server)
+            .await;
+
+        let result = request_with_timeouts(
+            &server.uri(),
+            "a@b.com",
+            std::time::Duration::from_millis(50),
+            std::time::Duration::from_millis(50),
+        )
+        .await;
+        assert!(matches!(result, Err(EnrollError::Http(_))));
     }
 
     #[tokio::test]

--- a/replicant-client/src/enrollment.rs
+++ b/replicant-client/src/enrollment.rs
@@ -50,6 +50,8 @@ pub async fn claim(base_url: &str, email: &str, token: &str) -> Result<Credentia
 
     match resp.status().as_u16() {
         200 => {
+            // Any undecodable 200 body (missing/unparseable fields, non-JSON)
+            // is an invalid enrollment response, not a transport error.
             let creds = resp
                 .json::<Credentials>()
                 .await
@@ -157,6 +159,49 @@ mod tests {
             .await;
         assert!(matches!(
             claim(&oversized.uri(), "a@b.com", "TOK").await,
+            Err(EnrollError::InvalidResponse)
+        ));
+
+        let bad_secret_prefix = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/enroll/claim"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "api_key": "rpa_x", "secret": "xxx_bad", "user_id": user_id
+            })))
+            .mount(&bad_secret_prefix)
+            .await;
+        assert!(matches!(
+            claim(&bad_secret_prefix.uri(), "a@b.com", "TOK").await,
+            Err(EnrollError::InvalidResponse)
+        ));
+
+        let oversized_secret = MockServer::start().await;
+        let oversized_secret_value = format!("rps_{}", "a".repeat(200));
+        Mock::given(method("POST"))
+            .and(path("/api/enroll/claim"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "api_key": "rpa_x", "secret": oversized_secret_value, "user_id": user_id
+            })))
+            .mount(&oversized_secret)
+            .await;
+        assert!(matches!(
+            claim(&oversized_secret.uri(), "a@b.com", "TOK").await,
+            Err(EnrollError::InvalidResponse)
+        ));
+    }
+
+    #[tokio::test]
+    async fn claim_rejects_unparseable_user_id() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/enroll/claim"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "api_key": "rpa_x", "secret": "rps_y", "user_id": "not-a-uuid"
+            })))
+            .mount(&server)
+            .await;
+        assert!(matches!(
+            claim(&server.uri(), "a@b.com", "TOK").await,
             Err(EnrollError::InvalidResponse)
         ));
     }

--- a/replicant-client/src/enrollment.rs
+++ b/replicant-client/src/enrollment.rs
@@ -45,7 +45,11 @@ fn validate_url(base_url: &str) -> Result<(), EnrollError> {
 }
 
 fn build_client(connect_timeout: Duration, timeout: Duration) -> reqwest::Client {
+    // Never follow redirects: a redirect to another host (or an https→http
+    // downgrade) would re-send the email and token to a URL we never
+    // validated.
     reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
         .connect_timeout(connect_timeout)
         .timeout(timeout)
         .build()
@@ -157,6 +161,37 @@ mod tests {
         let creds = claim(&server.uri(), "a@b.com", "TOK").await.unwrap();
         assert_eq!(creds.api_key, "rpa_x");
         assert_eq!(creds.user_id, user_id);
+    }
+
+    #[tokio::test]
+    async fn claim_never_follows_redirects() {
+        // A 307 re-sends the POST body (email + token) to the Location
+        // target — possibly a different host or a plain-http downgrade. The
+        // client must surface the redirect status instead of following it.
+        let attacker = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/enroll/claim"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "api_key": "rpa_x", "secret": "rps_y", "user_id": uuid::Uuid::new_v4()
+            })))
+            .expect(0)
+            .mount(&attacker)
+            .await;
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/enroll/claim"))
+            .respond_with(ResponseTemplate::new(307).insert_header(
+                "location",
+                format!("{}/api/enroll/claim", attacker.uri()).as_str(),
+            ))
+            .mount(&server)
+            .await;
+
+        assert!(matches!(
+            claim(&server.uri(), "a@b.com", "TOK").await,
+            Err(EnrollError::Http(s)) if s.contains("307")
+        ));
     }
 
     #[tokio::test]

--- a/replicant-client/src/enrollment.rs
+++ b/replicant-client/src/enrollment.rs
@@ -7,6 +7,22 @@ pub enum EnrollError {
     InvalidToken,
     #[error("enrollment request failed: {0}")]
     Http(String),
+    #[error("enrollment response invalid or incomplete")]
+    InvalidResponse,
+}
+
+const MAX_CRED_LEN: usize = 128;
+
+fn validate(creds: &Credentials) -> Result<(), EnrollError> {
+    if creds.user_id.is_nil()
+        || !creds.api_key.starts_with("rpa_")
+        || creds.api_key.len() > MAX_CRED_LEN
+        || !creds.secret.starts_with("rps_")
+        || creds.secret.len() > MAX_CRED_LEN
+    {
+        return Err(EnrollError::InvalidResponse);
+    }
+    Ok(())
 }
 
 pub async fn request(base_url: &str, email: &str) -> Result<(), EnrollError> {
@@ -33,10 +49,14 @@ pub async fn claim(base_url: &str, email: &str, token: &str) -> Result<Credentia
         .map_err(|e| EnrollError::Http(e.to_string()))?;
 
     match resp.status().as_u16() {
-        200 => resp
-            .json::<Credentials>()
-            .await
-            .map_err(|e| EnrollError::Http(e.to_string())),
+        200 => {
+            let creds = resp
+                .json::<Credentials>()
+                .await
+                .map_err(|_| EnrollError::InvalidResponse)?;
+            validate(&creds)?;
+            Ok(creds)
+        }
         401 => Err(EnrollError::InvalidToken),
         s => Err(EnrollError::Http(format!("status {s}"))),
     }
@@ -63,17 +83,82 @@ mod tests {
     #[tokio::test]
     async fn claim_returns_credentials_on_200() {
         let server = MockServer::start().await;
+        let user_id = uuid::Uuid::new_v4();
+        Mock::given(method("POST"))
+            .and(path("/api/enroll/claim"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "api_key": "rpa_x", "secret": "rps_y", "user_id": user_id
+            })))
+            .mount(&server)
+            .await;
+
+        let creds = claim(&server.uri(), "a@b.com", "TOK").await.unwrap();
+        assert_eq!(creds.api_key, "rpa_x");
+        assert_eq!(creds.user_id, user_id);
+    }
+
+    #[tokio::test]
+    async fn claim_rejects_missing_or_nil_user_id() {
+        let missing = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/api/enroll/claim"))
             .respond_with(
                 ResponseTemplate::new(200)
                     .set_body_json(serde_json::json!({"api_key":"rpa_x","secret":"rps_y"})),
             )
-            .mount(&server)
+            .mount(&missing)
             .await;
+        assert!(matches!(
+            claim(&missing.uri(), "a@b.com", "TOK").await,
+            Err(EnrollError::InvalidResponse)
+        ));
 
-        let creds = claim(&server.uri(), "a@b.com", "TOK").await.unwrap();
-        assert_eq!(creds.api_key, "rpa_x");
+        let nil = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/enroll/claim"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "api_key": "rpa_x",
+                "secret": "rps_y",
+                "user_id": "00000000-0000-0000-0000-000000000000"
+            })))
+            .mount(&nil)
+            .await;
+        assert!(matches!(
+            claim(&nil.uri(), "a@b.com", "TOK").await,
+            Err(EnrollError::InvalidResponse)
+        ));
+    }
+
+    #[tokio::test]
+    async fn claim_rejects_bad_prefix_or_oversized_fields() {
+        let user_id = uuid::Uuid::new_v4();
+
+        let bad_prefix = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/enroll/claim"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "api_key": "xxx_bad", "secret": "rps_y", "user_id": user_id
+            })))
+            .mount(&bad_prefix)
+            .await;
+        assert!(matches!(
+            claim(&bad_prefix.uri(), "a@b.com", "TOK").await,
+            Err(EnrollError::InvalidResponse)
+        ));
+
+        let oversized = MockServer::start().await;
+        let oversized_key = format!("rpa_{}", "a".repeat(200));
+        Mock::given(method("POST"))
+            .and(path("/api/enroll/claim"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "api_key": oversized_key, "secret": "rps_y", "user_id": user_id
+            })))
+            .mount(&oversized)
+            .await;
+        assert!(matches!(
+            claim(&oversized.uri(), "a@b.com", "TOK").await,
+            Err(EnrollError::InvalidResponse)
+        ));
     }
 
     #[tokio::test]

--- a/replicant-client/src/enrollment.rs
+++ b/replicant-client/src/enrollment.rs
@@ -33,19 +33,15 @@ fn validate(creds: &Credentials) -> Result<(), EnrollError> {
 /// Requires `https://`, except `http://localhost` / `http://127.0.0.1`
 /// (any port) for tests and local dev.
 fn validate_url(base_url: &str) -> Result<(), EnrollError> {
-    if base_url.starts_with("https://") {
-        return Ok(());
+    let parsed = url::Url::parse(base_url).map_err(|_| EnrollError::InsecureUrl)?;
+    match parsed.scheme().to_ascii_lowercase().as_str() {
+        "https" => Ok(()),
+        "http" => match parsed.host_str() {
+            Some("localhost") | Some("127.0.0.1") => Ok(()),
+            _ => Err(EnrollError::InsecureUrl),
+        },
+        _ => Err(EnrollError::InsecureUrl),
     }
-    if let Ok(parsed) = url::Url::parse(base_url) {
-        if parsed.scheme() == "http" {
-            if let Some(host) = parsed.host_str() {
-                if host == "localhost" || host == "127.0.0.1" {
-                    return Ok(());
-                }
-            }
-        }
-    }
-    Err(EnrollError::InsecureUrl)
 }
 
 fn build_client(connect_timeout: Duration, timeout: Duration) -> reqwest::Client {
@@ -54,6 +50,18 @@ fn build_client(connect_timeout: Duration, timeout: Duration) -> reqwest::Client
         .timeout(timeout)
         .build()
         .expect("reqwest client config is always valid")
+}
+
+/// reqwest's `Display` for a timed-out request doesn't mention "timeout"
+/// (e.g. "error sending request for url (...)"); surface it explicitly via
+/// `is_timeout()` so callers can distinguish timeouts from other transport
+/// failures without string-matching reqwest's undocumented wording.
+fn map_request_error(e: reqwest::Error) -> EnrollError {
+    if e.is_timeout() {
+        EnrollError::Http(format!("request timed out: {e}"))
+    } else {
+        EnrollError::Http(e.to_string())
+    }
 }
 
 pub async fn request(base_url: &str, email: &str) -> Result<(), EnrollError> {
@@ -72,7 +80,7 @@ async fn request_with_timeouts(
         .json(&serde_json::json!({ "email": email }))
         .send()
         .await
-        .map_err(|e| EnrollError::Http(e.to_string()))?;
+        .map_err(map_request_error)?;
 
     if resp.status().as_u16() == 202 {
         Ok(())
@@ -98,7 +106,7 @@ async fn claim_with_timeouts(
         .json(&serde_json::json!({ "email": email, "token": token }))
         .send()
         .await
-        .map_err(|e| EnrollError::Http(e.to_string()))?;
+        .map_err(map_request_error)?;
 
     match resp.status().as_u16() {
         200 => {
@@ -290,6 +298,13 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn validate_url_accepts_uppercase_https_scheme() {
+        assert!(validate_url("HTTPS://example.com").is_ok());
+        assert!(validate_url("HTTP://example.com").is_err());
+        assert!(validate_url("HTTP://localhost").is_ok());
+    }
+
+    #[tokio::test]
     async fn request_times_out() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
@@ -307,7 +322,10 @@ mod tests {
             std::time::Duration::from_millis(50),
         )
         .await;
-        assert!(matches!(result, Err(EnrollError::Http(_))));
+        assert!(
+            matches!(&result, Err(EnrollError::Http(msg)) if msg.to_lowercase().contains("time")),
+            "expected a timeout-flavored Http error, got {result:?}"
+        );
     }
 
     #[tokio::test]

--- a/replicant-client/src/ffi.rs
+++ b/replicant-client/src/ffi.rs
@@ -67,6 +67,7 @@ pub unsafe extern "C" fn replicant_create(
     email: *const c_char,
     api_key: *const c_char,
     api_secret: *const c_char,
+    user_id: *const c_char,
 ) -> *mut Replicant {
     if database_url.is_null()
         || server_url.is_null()
@@ -76,6 +77,21 @@ pub unsafe extern "C" fn replicant_create(
     {
         return ptr::null_mut();
     }
+
+    // Canonical user id from stored credentials; null means no enrolled
+    // identity (offline/local-only). A non-null id must be a real UUID.
+    let canonical_user_id = if user_id.is_null() {
+        None
+    } else {
+        match CStr::from_ptr(user_id)
+            .to_str()
+            .ok()
+            .and_then(|s| Uuid::parse_str(s).ok())
+        {
+            Some(id) if !id.is_nil() => Some(id),
+            _ => return ptr::null_mut(),
+        }
+    };
 
     let database_url = match CStr::from_ptr(database_url).to_str() {
         Ok(s) => s,
@@ -150,9 +166,7 @@ pub unsafe extern "C" fn replicant_create(
             &email,
             &api_key,
             &api_secret,
-            // Canonical id plumbed through the C ABI in a follow-up change;
-            // until then adoption never triggers via FFI construction.
-            None,
+            canonical_user_id,
             Some(event_dispatcher_clone.clone()),
         )
         .await
@@ -1249,14 +1263,24 @@ pub unsafe extern "C" fn replicant_rebuild_search_index(engine: *mut Replicant) 
 // Enrollment + credential storage
 // ============================================================================
 
-/// Copies `s` (plus a NUL terminator) into the caller-provided `out` buffer.
+/// Copies `s` plus a NUL terminator into `out` iff it fits within `cap`
+/// bytes. Returns `false` — writing an empty C string when `cap > 0` — when
+/// it does not fit; never writes past `cap`.
 ///
 /// # Safety
-/// `out` must point to a writable buffer of at least `s.len() + 1` bytes.
-unsafe fn write_cstr_buf(out: *mut c_char, s: &str) {
+/// `out` must point to a writable buffer of at least `cap` bytes.
+unsafe fn write_cstr_buf(out: *mut c_char, cap: usize, s: &str) -> bool {
+    if cap == 0 {
+        return false;
+    }
     let bytes = s.as_bytes();
+    if bytes.len() + 1 > cap {
+        out.write(0);
+        return false;
+    }
     ptr::copy_nonoverlapping(bytes.as_ptr(), out as *mut u8, bytes.len());
     out.add(bytes.len()).write(0);
+    true
 }
 
 /// Requests an enrollment token be emailed to `email`. Standalone HTTP call
@@ -1294,24 +1318,31 @@ pub unsafe extern "C" fn replicant_enroll_request(
 }
 
 /// Exchanges an enrollment token for a per-user credential. On success writes
-/// the api_key and secret into the out buffers (each must hold >= 69 bytes).
+/// the api_key, secret, and canonical user id (36-char UUID string) into the
+/// out buffers; each `*_cap` is the writable size of its buffer in bytes and
+/// the call fails (without overflowing) when a value does not fit.
 ///
 /// # Safety
-/// All string pointers must be valid, non-null C strings; `out_api_key` and
-/// `out_secret` must each point to a writable buffer of at least 69 bytes.
+/// All string pointers must be valid, non-null C strings; each out pointer
+/// must reference a writable buffer of at least its stated capacity.
 #[no_mangle]
 pub unsafe extern "C" fn replicant_enroll_claim(
     base_url: *const c_char,
     email: *const c_char,
     token: *const c_char,
     out_api_key: *mut c_char,
+    api_key_cap: usize,
     out_secret: *mut c_char,
+    secret_cap: usize,
+    out_user_id: *mut c_char,
+    user_id_cap: usize,
 ) -> SyncResult {
     if base_url.is_null()
         || email.is_null()
         || token.is_null()
         || out_api_key.is_null()
         || out_secret.is_null()
+        || out_user_id.is_null()
     {
         return SyncResult::ErrorInvalidInput;
     }
@@ -1336,27 +1367,40 @@ pub unsafe extern "C" fn replicant_enroll_claim(
 
     match runtime.block_on(crate::enrollment::claim(base_url, email, token)) {
         Ok(creds) => {
-            write_cstr_buf(out_api_key, &creds.api_key);
-            write_cstr_buf(out_secret, &creds.secret);
-            SyncResult::Success
+            if write_cstr_buf(out_api_key, api_key_cap, &creds.api_key)
+                && write_cstr_buf(out_secret, secret_cap, &creds.secret)
+                && write_cstr_buf(out_user_id, user_id_cap, &creds.user_id.to_string())
+            {
+                SyncResult::Success
+            } else {
+                SyncResult::ErrorInvalidInput
+            }
         }
         Err(crate::enrollment::EnrollError::InvalidToken) => SyncResult::ErrorInvalidInput,
         Err(_) => SyncResult::ErrorConnection,
     }
 }
 
-/// Loads stored credentials from `data_dir`. Returns Success and fills the out
-/// buffers, or ErrorDatabase if none are stored / unreadable.
+/// Loads stored credentials from `data_dir`. Returns Success and fills the
+/// out buffers (api_key, secret, canonical user id), or ErrorDatabase if none
+/// are stored / unreadable. Each `*_cap` is the writable size of its buffer;
+/// the call fails (without overflowing) when a value does not fit.
 ///
 /// # Safety
-/// `data_dir` must be a valid, non-null C string; out buffers each >= 69 bytes.
+/// `data_dir` must be a valid, non-null C string; each out pointer must
+/// reference a writable buffer of at least its stated capacity.
 #[no_mangle]
 pub unsafe extern "C" fn replicant_load_credentials(
     data_dir: *const c_char,
     out_api_key: *mut c_char,
+    api_key_cap: usize,
     out_secret: *mut c_char,
+    secret_cap: usize,
+    out_user_id: *mut c_char,
+    user_id_cap: usize,
 ) -> SyncResult {
-    if data_dir.is_null() || out_api_key.is_null() || out_secret.is_null() {
+    if data_dir.is_null() || out_api_key.is_null() || out_secret.is_null() || out_user_id.is_null()
+    {
         return SyncResult::ErrorInvalidInput;
     }
 
@@ -1367,15 +1411,23 @@ pub unsafe extern "C" fn replicant_load_credentials(
 
     match crate::secret_store::load(std::path::Path::new(data_dir)) {
         Ok(Some(creds)) => {
-            write_cstr_buf(out_api_key, &creds.api_key);
-            write_cstr_buf(out_secret, &creds.secret);
-            SyncResult::Success
+            if write_cstr_buf(out_api_key, api_key_cap, &creds.api_key)
+                && write_cstr_buf(out_secret, secret_cap, &creds.secret)
+                && write_cstr_buf(out_user_id, user_id_cap, &creds.user_id.to_string())
+            {
+                SyncResult::Success
+            } else {
+                SyncResult::ErrorInvalidInput
+            }
         }
         Ok(None) | Err(_) => SyncResult::ErrorDatabase,
     }
 }
 
-/// Stores credentials to `data_dir` (encrypted at rest).
+/// Stores credentials to `data_dir` (encrypted at rest). `user_id` is the
+/// canonical id delivered by enrollment claim (36-char UUID string); a nil or
+/// unparseable id is rejected — credentials are never stored without a real
+/// identity.
 ///
 /// # Safety
 /// All pointers must be valid, non-null C strings.
@@ -1384,8 +1436,9 @@ pub unsafe extern "C" fn replicant_store_credentials(
     data_dir: *const c_char,
     api_key: *const c_char,
     secret: *const c_char,
+    user_id: *const c_char,
 ) -> SyncResult {
-    if data_dir.is_null() || api_key.is_null() || secret.is_null() {
+    if data_dir.is_null() || api_key.is_null() || secret.is_null() || user_id.is_null() {
         return SyncResult::ErrorInvalidInput;
     }
 
@@ -1401,13 +1454,19 @@ pub unsafe extern "C" fn replicant_store_credentials(
         Ok(s) => s,
         Err(_) => return SyncResult::ErrorInvalidInput,
     };
+    let user_id = match CStr::from_ptr(user_id)
+        .to_str()
+        .ok()
+        .and_then(|s| Uuid::parse_str(s).ok())
+    {
+        Some(id) if !id.is_nil() => id,
+        _ => return SyncResult::ErrorInvalidInput,
+    };
 
-    // The C ABI for this call doesn't carry user_id yet (Task 7); store a nil
-    // placeholder so the encrypted-at-rest struct still round-trips.
     let creds = crate::secret_store::Credentials {
         api_key: api_key.to_string(),
         secret: secret.to_string(),
-        user_id: Uuid::nil(),
+        user_id,
     };
 
     match crate::secret_store::store(std::path::Path::new(data_dir), &creds) {
@@ -1434,5 +1493,36 @@ pub unsafe extern "C" fn replicant_clear_credentials(data_dir: *const c_char) ->
     match crate::secret_store::clear(std::path::Path::new(data_dir)) {
         Ok(()) => SyncResult::Success,
         Err(_) => SyncResult::ErrorDatabase,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_cstr_buf_refuses_oversized_strings() {
+        let mut small = [1i8; 8];
+        let fitted = unsafe {
+            write_cstr_buf(
+                small.as_mut_ptr() as *mut c_char,
+                small.len(),
+                "too-long-for-8",
+            )
+        };
+        assert!(!fitted);
+        assert_eq!(small[0], 0, "refused write must leave an empty C string");
+
+        let mut big = [1i8; 32];
+        let fitted = unsafe { write_cstr_buf(big.as_mut_ptr() as *mut c_char, big.len(), "fits") };
+        assert!(fitted);
+        assert_eq!(big[4], 0, "NUL terminator after the copied bytes");
+    }
+
+    #[test]
+    fn write_cstr_buf_zero_capacity_is_refused() {
+        let mut buf = [1i8; 1];
+        assert!(!unsafe { write_cstr_buf(buf.as_mut_ptr() as *mut c_char, 0, "") });
+        assert_eq!(buf[0], 1, "zero-cap buffer must not be touched");
     }
 }

--- a/replicant-client/src/ffi.rs
+++ b/replicant-client/src/ffi.rs
@@ -1265,7 +1265,9 @@ pub unsafe extern "C" fn replicant_rebuild_search_index(engine: *mut Replicant) 
 
 /// Copies `s` plus a NUL terminator into `out` iff it fits within `cap`
 /// bytes. Returns `false` — writing an empty C string when `cap > 0` — when
-/// it does not fit; never writes past `cap`.
+/// it does not fit; never writes past `cap`. On a multi-buffer call that
+/// fails partway, earlier out buffers may already be populated — callers
+/// must not read any out buffer unless the call returned success.
 ///
 /// # Safety
 /// `out` must point to a writable buffer of at least `cap` bytes.
@@ -1517,6 +1519,16 @@ mod tests {
         let fitted = unsafe { write_cstr_buf(big.as_mut_ptr() as *mut c_char, big.len(), "fits") };
         assert!(fitted);
         assert_eq!(big[4], 0, "NUL terminator after the copied bytes");
+    }
+
+    #[test]
+    fn write_cstr_buf_exact_fit_boundary() {
+        // len + 1 == cap fits exactly; len == cap does not.
+        let mut buf = [1i8; 5];
+        assert!(unsafe { write_cstr_buf(buf.as_mut_ptr() as *mut c_char, buf.len(), "four") });
+        assert_eq!(buf[4], 0);
+        assert!(!unsafe { write_cstr_buf(buf.as_mut_ptr() as *mut c_char, buf.len(), "five!") });
+        assert_eq!(buf[0], 0, "refused write must leave an empty C string");
     }
 
     #[test]

--- a/replicant-client/src/ffi.rs
+++ b/replicant-client/src/ffi.rs
@@ -1549,4 +1549,34 @@ mod tests {
         assert!(!unsafe { write_cstr_buf(buf.as_mut_ptr() as *mut c_char, 0, "") });
         assert_eq!(buf[0], 1, "zero-cap buffer must not be touched");
     }
+
+    #[tokio::test]
+    async fn enroll_ffi_is_callable_from_within_a_runtime() {
+        // Pre-guard code panicked here ("Cannot start a runtime from within a
+        // runtime"); the OS-thread hop makes this safe. The insecure URL makes
+        // the call fail fast without any network traffic.
+        let url = CString::new("http://example.com").unwrap();
+        let email = CString::new("rt@test.com").unwrap();
+        let result = unsafe { replicant_enroll_request(url.as_ptr(), email.as_ptr()) };
+        assert_ne!(result, SyncResult::Success);
+
+        let token = CString::new("TOK").unwrap();
+        let mut key = [0i8; 129];
+        let mut secret = [0i8; 129];
+        let mut uid = [0i8; 37];
+        let result = unsafe {
+            replicant_enroll_claim(
+                url.as_ptr(),
+                email.as_ptr(),
+                token.as_ptr(),
+                key.as_mut_ptr() as *mut c_char,
+                key.len(),
+                secret.as_mut_ptr() as *mut c_char,
+                secret.len(),
+                uid.as_mut_ptr() as *mut c_char,
+                uid.len(),
+            )
+        };
+        assert_ne!(result, SyncResult::Success);
+    }
 }

--- a/replicant-client/src/ffi.rs
+++ b/replicant-client/src/ffi.rs
@@ -1286,7 +1286,8 @@ unsafe fn write_cstr_buf(out: *mut c_char, cap: usize, s: &str) -> bool {
 }
 
 /// Requests an enrollment token be emailed to `email`. Standalone HTTP call
-/// (no engine handle); spins a short-lived runtime to drive the async request.
+/// (no engine handle); runs on a dedicated thread with its own short-lived
+/// runtime so this is safe to call even from inside an async runtime context.
 ///
 /// # Safety
 /// `base_url` and `email` must be valid, non-null C strings.
@@ -1300,22 +1301,27 @@ pub unsafe extern "C" fn replicant_enroll_request(
     }
 
     let base_url = match CStr::from_ptr(base_url).to_str() {
-        Ok(s) => s,
+        Ok(s) => s.to_string(),
         Err(_) => return SyncResult::ErrorInvalidInput,
     };
     let email = match CStr::from_ptr(email).to_str() {
-        Ok(s) => s,
+        Ok(s) => s.to_string(),
         Err(_) => return SyncResult::ErrorInvalidInput,
     };
 
-    let runtime = match Runtime::new() {
-        Ok(r) => r,
-        Err(_) => return SyncResult::ErrorUnknown,
-    };
+    let join_result = std::thread::spawn(move || {
+        let runtime = Runtime::new().map_err(|_| SyncResult::ErrorUnknown)?;
+        match runtime.block_on(crate::enrollment::request(&base_url, &email)) {
+            Ok(()) => Ok(()),
+            Err(_) => Err(SyncResult::ErrorConnection),
+        }
+    })
+    .join();
 
-    match runtime.block_on(crate::enrollment::request(base_url, email)) {
-        Ok(()) => SyncResult::Success,
-        Err(_) => SyncResult::ErrorConnection,
+    match join_result {
+        Ok(Ok(())) => SyncResult::Success,
+        Ok(Err(err)) => err,
+        Err(_) => SyncResult::ErrorUnknown,
     }
 }
 
@@ -1350,25 +1356,31 @@ pub unsafe extern "C" fn replicant_enroll_claim(
     }
 
     let base_url = match CStr::from_ptr(base_url).to_str() {
-        Ok(s) => s,
+        Ok(s) => s.to_string(),
         Err(_) => return SyncResult::ErrorInvalidInput,
     };
     let email = match CStr::from_ptr(email).to_str() {
-        Ok(s) => s,
+        Ok(s) => s.to_string(),
         Err(_) => return SyncResult::ErrorInvalidInput,
     };
     let token = match CStr::from_ptr(token).to_str() {
-        Ok(s) => s,
+        Ok(s) => s.to_string(),
         Err(_) => return SyncResult::ErrorInvalidInput,
     };
 
-    let runtime = match Runtime::new() {
-        Ok(r) => r,
-        Err(_) => return SyncResult::ErrorUnknown,
-    };
+    let join_result = std::thread::spawn(move || {
+        let runtime = Runtime::new().map_err(|_| SyncResult::ErrorUnknown)?;
+        runtime
+            .block_on(crate::enrollment::claim(&base_url, &email, &token))
+            .map_err(|e| match e {
+                crate::enrollment::EnrollError::InvalidToken => SyncResult::ErrorInvalidInput,
+                _ => SyncResult::ErrorConnection,
+            })
+    })
+    .join();
 
-    match runtime.block_on(crate::enrollment::claim(base_url, email, token)) {
-        Ok(creds) => {
+    match join_result {
+        Ok(Ok(creds)) => {
             if write_cstr_buf(out_api_key, api_key_cap, &creds.api_key)
                 && write_cstr_buf(out_secret, secret_cap, &creds.secret)
                 && write_cstr_buf(out_user_id, user_id_cap, &creds.user_id.to_string())
@@ -1378,8 +1390,8 @@ pub unsafe extern "C" fn replicant_enroll_claim(
                 SyncResult::ErrorInvalidInput
             }
         }
-        Err(crate::enrollment::EnrollError::InvalidToken) => SyncResult::ErrorInvalidInput,
-        Err(_) => SyncResult::ErrorConnection,
+        Ok(Err(err)) => err,
+        Err(_) => SyncResult::ErrorUnknown,
     }
 }
 

--- a/replicant-client/src/ffi.rs
+++ b/replicant-client/src/ffi.rs
@@ -1402,9 +1402,12 @@ pub unsafe extern "C" fn replicant_store_credentials(
         Err(_) => return SyncResult::ErrorInvalidInput,
     };
 
+    // The C ABI for this call doesn't carry user_id yet (Task 7); store a nil
+    // placeholder so the encrypted-at-rest struct still round-trips.
     let creds = crate::secret_store::Credentials {
         api_key: api_key.to_string(),
         secret: secret.to_string(),
+        user_id: Uuid::nil(),
     };
 
     match crate::secret_store::store(std::path::Path::new(data_dir), &creds) {

--- a/replicant-client/src/ffi.rs
+++ b/replicant-client/src/ffi.rs
@@ -1244,3 +1244,192 @@ pub unsafe extern "C" fn replicant_rebuild_search_index(engine: *mut Replicant) 
         Err(_) => SyncResult::ErrorDatabase,
     }
 }
+
+// ============================================================================
+// Enrollment + credential storage
+// ============================================================================
+
+/// Copies `s` (plus a NUL terminator) into the caller-provided `out` buffer.
+///
+/// # Safety
+/// `out` must point to a writable buffer of at least `s.len() + 1` bytes.
+unsafe fn write_cstr_buf(out: *mut c_char, s: &str) {
+    let bytes = s.as_bytes();
+    ptr::copy_nonoverlapping(bytes.as_ptr(), out as *mut u8, bytes.len());
+    out.add(bytes.len()).write(0);
+}
+
+/// Requests an enrollment token be emailed to `email`. Standalone HTTP call
+/// (no engine handle); spins a short-lived runtime to drive the async request.
+///
+/// # Safety
+/// `base_url` and `email` must be valid, non-null C strings.
+#[no_mangle]
+pub unsafe extern "C" fn replicant_enroll_request(
+    base_url: *const c_char,
+    email: *const c_char,
+) -> SyncResult {
+    if base_url.is_null() || email.is_null() {
+        return SyncResult::ErrorInvalidInput;
+    }
+
+    let base_url = match CStr::from_ptr(base_url).to_str() {
+        Ok(s) => s,
+        Err(_) => return SyncResult::ErrorInvalidInput,
+    };
+    let email = match CStr::from_ptr(email).to_str() {
+        Ok(s) => s,
+        Err(_) => return SyncResult::ErrorInvalidInput,
+    };
+
+    let runtime = match Runtime::new() {
+        Ok(r) => r,
+        Err(_) => return SyncResult::ErrorUnknown,
+    };
+
+    match runtime.block_on(crate::enrollment::request(base_url, email)) {
+        Ok(()) => SyncResult::Success,
+        Err(_) => SyncResult::ErrorConnection,
+    }
+}
+
+/// Exchanges an enrollment token for a per-user credential. On success writes
+/// the api_key and secret into the out buffers (each must hold >= 69 bytes).
+///
+/// # Safety
+/// All string pointers must be valid, non-null C strings; `out_api_key` and
+/// `out_secret` must each point to a writable buffer of at least 69 bytes.
+#[no_mangle]
+pub unsafe extern "C" fn replicant_enroll_claim(
+    base_url: *const c_char,
+    email: *const c_char,
+    token: *const c_char,
+    out_api_key: *mut c_char,
+    out_secret: *mut c_char,
+) -> SyncResult {
+    if base_url.is_null()
+        || email.is_null()
+        || token.is_null()
+        || out_api_key.is_null()
+        || out_secret.is_null()
+    {
+        return SyncResult::ErrorInvalidInput;
+    }
+
+    let base_url = match CStr::from_ptr(base_url).to_str() {
+        Ok(s) => s,
+        Err(_) => return SyncResult::ErrorInvalidInput,
+    };
+    let email = match CStr::from_ptr(email).to_str() {
+        Ok(s) => s,
+        Err(_) => return SyncResult::ErrorInvalidInput,
+    };
+    let token = match CStr::from_ptr(token).to_str() {
+        Ok(s) => s,
+        Err(_) => return SyncResult::ErrorInvalidInput,
+    };
+
+    let runtime = match Runtime::new() {
+        Ok(r) => r,
+        Err(_) => return SyncResult::ErrorUnknown,
+    };
+
+    match runtime.block_on(crate::enrollment::claim(base_url, email, token)) {
+        Ok(creds) => {
+            write_cstr_buf(out_api_key, &creds.api_key);
+            write_cstr_buf(out_secret, &creds.secret);
+            SyncResult::Success
+        }
+        Err(crate::enrollment::EnrollError::InvalidToken) => SyncResult::ErrorInvalidInput,
+        Err(_) => SyncResult::ErrorConnection,
+    }
+}
+
+/// Loads stored credentials from `data_dir`. Returns Success and fills the out
+/// buffers, or ErrorDatabase if none are stored / unreadable.
+///
+/// # Safety
+/// `data_dir` must be a valid, non-null C string; out buffers each >= 69 bytes.
+#[no_mangle]
+pub unsafe extern "C" fn replicant_load_credentials(
+    data_dir: *const c_char,
+    out_api_key: *mut c_char,
+    out_secret: *mut c_char,
+) -> SyncResult {
+    if data_dir.is_null() || out_api_key.is_null() || out_secret.is_null() {
+        return SyncResult::ErrorInvalidInput;
+    }
+
+    let data_dir = match CStr::from_ptr(data_dir).to_str() {
+        Ok(s) => s,
+        Err(_) => return SyncResult::ErrorInvalidInput,
+    };
+
+    match crate::secret_store::load(std::path::Path::new(data_dir)) {
+        Ok(Some(creds)) => {
+            write_cstr_buf(out_api_key, &creds.api_key);
+            write_cstr_buf(out_secret, &creds.secret);
+            SyncResult::Success
+        }
+        Ok(None) | Err(_) => SyncResult::ErrorDatabase,
+    }
+}
+
+/// Stores credentials to `data_dir` (encrypted at rest).
+///
+/// # Safety
+/// All pointers must be valid, non-null C strings.
+#[no_mangle]
+pub unsafe extern "C" fn replicant_store_credentials(
+    data_dir: *const c_char,
+    api_key: *const c_char,
+    secret: *const c_char,
+) -> SyncResult {
+    if data_dir.is_null() || api_key.is_null() || secret.is_null() {
+        return SyncResult::ErrorInvalidInput;
+    }
+
+    let data_dir = match CStr::from_ptr(data_dir).to_str() {
+        Ok(s) => s,
+        Err(_) => return SyncResult::ErrorInvalidInput,
+    };
+    let api_key = match CStr::from_ptr(api_key).to_str() {
+        Ok(s) => s,
+        Err(_) => return SyncResult::ErrorInvalidInput,
+    };
+    let secret = match CStr::from_ptr(secret).to_str() {
+        Ok(s) => s,
+        Err(_) => return SyncResult::ErrorInvalidInput,
+    };
+
+    let creds = crate::secret_store::Credentials {
+        api_key: api_key.to_string(),
+        secret: secret.to_string(),
+    };
+
+    match crate::secret_store::store(std::path::Path::new(data_dir), &creds) {
+        Ok(()) => SyncResult::Success,
+        Err(_) => SyncResult::ErrorDatabase,
+    }
+}
+
+/// Clears any stored credentials in `data_dir`.
+///
+/// # Safety
+/// `data_dir` must be a valid, non-null C string.
+#[no_mangle]
+pub unsafe extern "C" fn replicant_clear_credentials(data_dir: *const c_char) -> SyncResult {
+    if data_dir.is_null() {
+        return SyncResult::ErrorInvalidInput;
+    }
+
+    let data_dir = match CStr::from_ptr(data_dir).to_str() {
+        Ok(s) => s,
+        Err(_) => return SyncResult::ErrorInvalidInput,
+    };
+
+    match crate::secret_store::clear(std::path::Path::new(data_dir)) {
+        Ok(()) => SyncResult::Success,
+        Err(_) => SyncResult::ErrorDatabase,
+    }
+}

--- a/replicant-client/src/ffi.rs
+++ b/replicant-client/src/ffi.rs
@@ -1267,7 +1267,9 @@ pub unsafe extern "C" fn replicant_rebuild_search_index(engine: *mut Replicant) 
 /// bytes. Returns `false` — writing an empty C string when `cap > 0` — when
 /// it does not fit; never writes past `cap`. On a multi-buffer call that
 /// fails partway, earlier out buffers may already be populated — callers
-/// must not read any out buffer unless the call returned success.
+/// must not read any out buffer unless the call returned success. Bytes of
+/// `s` are copied verbatim, so an embedded NUL makes C readers see the
+/// string truncated at that NUL.
 ///
 /// # Safety
 /// `out` must point to a writable buffer of at least `cap` bytes.

--- a/replicant-client/src/lib.rs
+++ b/replicant-client/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod client;
 pub mod database;
+pub mod enrollment;
 pub mod events;
 pub mod offline_queue;
 pub mod queries;

--- a/replicant-client/src/lib.rs
+++ b/replicant-client/src/lib.rs
@@ -3,6 +3,7 @@ pub mod database;
 pub mod events;
 pub mod offline_queue;
 pub mod queries;
+pub mod secret_store;
 pub mod websocket;
 
 // C FFI module

--- a/replicant-client/src/secret_store.rs
+++ b/replicant-client/src/secret_store.rs
@@ -18,21 +18,29 @@ pub struct Credentials {
     pub user_id: uuid::Uuid,
 }
 
-fn load_or_create_key(dir: &Path) -> io::Result<[u8; 32]> {
+/// Reads the at-rest key if present. Never creates one — callers that must
+/// mint a key when absent use [`load_or_create_key`].
+fn read_key(dir: &Path) -> io::Result<Option<[u8; 32]>> {
     let path = dir.join(KEY_FILE);
-    if path.exists() {
-        let bytes = std::fs::read(&path)?;
-        let arr: [u8; 32] = bytes
-            .try_into()
-            .map_err(|_| Error::new(ErrorKind::InvalidData, "bad key length"))?;
-        Ok(arr)
-    } else {
-        let mut key = [0u8; 32];
-        OsRng.fill_bytes(&mut key);
-        std::fs::create_dir_all(dir)?;
-        write_private(&path, &key)?;
-        Ok(key)
+    if !path.exists() {
+        return Ok(None);
     }
+    let bytes = std::fs::read(&path)?;
+    let arr: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| Error::new(ErrorKind::InvalidData, "bad key length"))?;
+    Ok(Some(arr))
+}
+
+fn load_or_create_key(dir: &Path) -> io::Result<[u8; 32]> {
+    if let Some(key) = read_key(dir)? {
+        return Ok(key);
+    }
+    let mut key = [0u8; 32];
+    OsRng.fill_bytes(&mut key);
+    std::fs::create_dir_all(dir)?;
+    write_private(&dir.join(KEY_FILE), &key)?;
+    Ok(key)
 }
 
 #[cfg(unix)]
@@ -77,7 +85,12 @@ pub fn load(dir: &Path) -> io::Result<Option<Credentials>> {
     if !path.exists() {
         return Ok(None);
     }
-    let key = load_or_create_key(dir)?;
+    // Never mint a key on the read path: an existing credentials file
+    // without a key is a broken/tampered state, not a "first run".
+    let key = match read_key(dir)? {
+        Some(key) => key,
+        None => return Ok(None),
+    };
     let cipher = ChaCha20Poly1305::new((&key).into());
 
     let bytes = std::fs::read(&path)?;
@@ -95,9 +108,13 @@ pub fn load(dir: &Path) -> io::Result<Option<Credentials>> {
 }
 
 pub fn clear(dir: &Path) -> io::Result<()> {
-    let p = dir.join(CRED_FILE);
-    if p.exists() {
-        std::fs::remove_file(p)?;
+    let cred_path = dir.join(CRED_FILE);
+    if cred_path.exists() {
+        std::fs::remove_file(cred_path)?;
+    }
+    let key_path = dir.join(KEY_FILE);
+    if key_path.exists() {
+        std::fs::remove_file(key_path)?;
     }
     Ok(())
 }
@@ -126,6 +143,38 @@ mod tests {
 
         clear(dir.path()).unwrap();
         assert!(load(dir.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn clear_removes_both_key_and_credentials_files() {
+        let dir = tempfile::tempdir().unwrap();
+        store(
+            dir.path(),
+            &Credentials {
+                api_key: "rpa_x".into(),
+                secret: "rps_y".into(),
+                user_id: uuid::Uuid::new_v4(),
+            },
+        )
+        .unwrap();
+        assert!(dir.path().join(KEY_FILE).exists());
+        assert!(dir.path().join(CRED_FILE).exists());
+
+        clear(dir.path()).unwrap();
+
+        assert!(!dir.path().join(KEY_FILE).exists());
+        assert!(!dir.path().join(CRED_FILE).exists());
+    }
+
+    #[test]
+    fn load_on_empty_dir_returns_none_and_mints_no_key() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(load(dir.path()).unwrap().is_none());
+        assert!(
+            !dir.path().join(KEY_FILE).exists(),
+            "load() must never mint a key"
+        );
+        assert!(!dir.path().join(CRED_FILE).exists());
     }
 
     #[test]

--- a/replicant-client/src/secret_store.rs
+++ b/replicant-client/src/secret_store.rs
@@ -15,6 +15,7 @@ const CRED_FILE: &str = "credentials.enc";
 pub struct Credentials {
     pub api_key: String,
     pub secret: String,
+    pub user_id: uuid::Uuid,
 }
 
 fn load_or_create_key(dir: &Path) -> io::Result<[u8; 32]> {
@@ -110,15 +111,18 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         assert!(load(dir.path()).unwrap().is_none());
 
+        let user_id = uuid::Uuid::new_v4();
         let creds = Credentials {
             api_key: "rpa_x".into(),
             secret: "rps_y".into(),
+            user_id,
         };
         store(dir.path(), &creds).unwrap();
 
         let loaded = load(dir.path()).unwrap().unwrap();
         assert_eq!(loaded.api_key, "rpa_x");
         assert_eq!(loaded.secret, "rps_y");
+        assert_eq!(loaded.user_id, user_id);
 
         clear(dir.path()).unwrap();
         assert!(load(dir.path()).unwrap().is_none());
@@ -132,6 +136,7 @@ mod tests {
             &Credentials {
                 api_key: "a".into(),
                 secret: "b".into(),
+                user_id: uuid::Uuid::new_v4(),
             },
         )
         .unwrap();

--- a/replicant-client/src/secret_store.rs
+++ b/replicant-client/src/secret_store.rs
@@ -1,0 +1,145 @@
+//! Encrypted-at-rest storage for the per-user sync credential.
+//! See plan doc for the at-rest key limitation (co-located key = obfuscation,
+//! not strong protection; DPAPI wrapping is a Windows follow-up).
+
+use chacha20poly1305::aead::{Aead, KeyInit, OsRng};
+use chacha20poly1305::{ChaCha20Poly1305, Nonce};
+use rand::RngCore;
+use std::io::{self, Error, ErrorKind};
+use std::path::Path;
+
+const KEY_FILE: &str = "key.bin";
+const CRED_FILE: &str = "credentials.enc";
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Credentials {
+    pub api_key: String,
+    pub secret: String,
+}
+
+fn load_or_create_key(dir: &Path) -> io::Result<[u8; 32]> {
+    let path = dir.join(KEY_FILE);
+    if path.exists() {
+        let bytes = std::fs::read(&path)?;
+        let arr: [u8; 32] = bytes
+            .try_into()
+            .map_err(|_| Error::new(ErrorKind::InvalidData, "bad key length"))?;
+        Ok(arr)
+    } else {
+        let mut key = [0u8; 32];
+        OsRng.fill_bytes(&mut key);
+        std::fs::create_dir_all(dir)?;
+        write_private(&path, &key)?;
+        Ok(key)
+    }
+}
+
+#[cfg(unix)]
+fn write_private(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)?;
+    f.write_all(bytes)
+}
+
+#[cfg(not(unix))]
+fn write_private(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    // TODO(hardening): wrap with DPAPI on Windows. For now rely on the
+    // user-profile directory ACL.
+    std::fs::write(path, bytes)
+}
+
+pub fn store(dir: &Path, creds: &Credentials) -> io::Result<()> {
+    let key = load_or_create_key(dir)?;
+    let cipher = ChaCha20Poly1305::new((&key).into());
+    let mut nonce_bytes = [0u8; 12];
+    OsRng.fill_bytes(&mut nonce_bytes);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let plaintext = serde_json::to_vec(creds).map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
+    let ciphertext = cipher
+        .encrypt(nonce, plaintext.as_ref())
+        .map_err(|_| Error::new(ErrorKind::Other, "encrypt failed"))?;
+
+    let mut out = nonce_bytes.to_vec();
+    out.extend_from_slice(&ciphertext);
+    write_private(&dir.join(CRED_FILE), &out)
+}
+
+pub fn load(dir: &Path) -> io::Result<Option<Credentials>> {
+    let path = dir.join(CRED_FILE);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let key = load_or_create_key(dir)?;
+    let cipher = ChaCha20Poly1305::new((&key).into());
+
+    let bytes = std::fs::read(&path)?;
+    if bytes.len() < 12 {
+        return Err(Error::new(ErrorKind::InvalidData, "truncated"));
+    }
+    let (nonce_bytes, ciphertext) = bytes.split_at(12);
+    let plaintext = cipher
+        .decrypt(Nonce::from_slice(nonce_bytes), ciphertext)
+        .map_err(|_| Error::new(ErrorKind::InvalidData, "decrypt failed"))?;
+
+    let creds =
+        serde_json::from_slice(&plaintext).map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
+    Ok(Some(creds))
+}
+
+pub fn clear(dir: &Path) -> io::Result<()> {
+    let p = dir.join(CRED_FILE);
+    if p.exists() {
+        std::fs::remove_file(p)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_credentials() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(load(dir.path()).unwrap().is_none());
+
+        let creds = Credentials {
+            api_key: "rpa_x".into(),
+            secret: "rps_y".into(),
+        };
+        store(dir.path(), &creds).unwrap();
+
+        let loaded = load(dir.path()).unwrap().unwrap();
+        assert_eq!(loaded.api_key, "rpa_x");
+        assert_eq!(loaded.secret, "rps_y");
+
+        clear(dir.path()).unwrap();
+        assert!(load(dir.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn tampered_ciphertext_fails_to_decrypt() {
+        let dir = tempfile::tempdir().unwrap();
+        store(
+            dir.path(),
+            &Credentials {
+                api_key: "a".into(),
+                secret: "b".into(),
+            },
+        )
+        .unwrap();
+        let cred_path = dir.path().join("credentials.enc");
+        let mut bytes = std::fs::read(&cred_path).unwrap();
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0xFF;
+        std::fs::write(&cred_path, bytes).unwrap();
+        assert!(load(dir.path()).is_err());
+    }
+}

--- a/replicant-client/src/websocket.rs
+++ b/replicant-client/src/websocket.rs
@@ -1,6 +1,6 @@
 use crate::events::EventDispatcher;
 use hmac::{Hmac, Mac};
-use phoenix_channels_client::{Channel, Event, Payload, Socket, Topic};
+use phoenix_channels_client::{Channel, ChannelStatus, Event, Payload, Socket, Topic};
 use replicant_core::{
     errors::ClientError,
     models::{Document, DocumentPatch},
@@ -143,7 +143,16 @@ impl WebSocketClient {
 
         let (tx, rx) = mpsc::channel::<ServerMessage>(100);
         Self::setup_broadcast_handlers(&channel, tx.clone(), is_connected.clone());
-        Self::setup_broadcast_handlers(&public_channel, tx.clone(), is_connected);
+        Self::setup_broadcast_handlers(&public_channel, tx.clone(), is_connected.clone());
+
+        // The phoenix client freezes the join payload (and its timestamp) at
+        // channel creation and replays it on every auto-rejoin; once the stamp
+        // is older than the server's clock-skew window every rejoin is rejected
+        // forever. A channel-level rejoin never flips is_connected, so watch the
+        // channel status and hand off to our own reconnect loop (which mints a
+        // fresh timestamp) when the library gets stuck rejoining.
+        Self::setup_status_watcher(&channel, is_connected.clone());
+        Self::setup_status_watcher(&public_channel, is_connected);
 
         // Emit auth success
         let _ = tx
@@ -200,6 +209,30 @@ impl WebSocketClient {
                 )),
             },
         }
+    }
+
+    /// Whether a channel status means the phoenix client is stuck rejoining
+    /// with its frozen (stale-timestamp) payload and our reconnect loop should
+    /// take over.
+    fn should_reconnect_on_status(status: &ChannelStatus) -> bool {
+        matches!(status, ChannelStatus::WaitingToRejoin { .. })
+    }
+
+    fn setup_status_watcher(channel: &Arc<Channel>, is_connected: Arc<AtomicBool>) {
+        let statuses = channel.statuses();
+
+        tokio::spawn(async move {
+            loop {
+                match statuses.status().await {
+                    Ok(status) => {
+                        if Self::should_reconnect_on_status(&status) {
+                            is_connected.store(false, Ordering::Relaxed);
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
     }
 
     fn to_websocket_url(server_url: &str) -> SyncResult<String> {
@@ -683,5 +716,27 @@ mod tests {
         let local = Uuid::new_v4();
         let reply = serde_json::json!({ "user_id": "not-a-uuid" });
         assert!(WebSocketClient::verify_reply_identity(local, &reply).is_err());
+    }
+
+    #[test]
+    fn should_reconnect_on_waiting_to_rejoin() {
+        let status = ChannelStatus::WaitingToRejoin {
+            until: std::time::SystemTime::now(),
+        };
+        assert!(WebSocketClient::should_reconnect_on_status(&status));
+    }
+
+    #[test]
+    fn should_not_reconnect_on_steady_statuses() {
+        for status in [
+            ChannelStatus::Joined,
+            ChannelStatus::Joining,
+            ChannelStatus::WaitingToJoin,
+            ChannelStatus::WaitingForSocketToConnect,
+            ChannelStatus::Leaving,
+            ChannelStatus::Left,
+        ] {
+            assert!(!WebSocketClient::should_reconnect_on_status(&status));
+        }
     }
 }

--- a/replicant-client/src/websocket.rs
+++ b/replicant-client/src/websocket.rs
@@ -1,6 +1,8 @@
 use crate::events::EventDispatcher;
 use hmac::{Hmac, Mac};
-use phoenix_channels_client::{Channel, ChannelStatus, Event, Payload, Socket, Topic};
+use phoenix_channels_client::{
+    Channel, ChannelStatus, Event, Payload, Socket, StatusesError, Topic,
+};
 use replicant_core::{
     errors::ClientError,
     models::{Document, DocumentPatch},
@@ -229,7 +231,10 @@ impl WebSocketClient {
                             is_connected.store(false, Ordering::Relaxed);
                         }
                     }
-                    Err(_) => break,
+                    // Only a closed status channel ends the watch; a lagged
+                    // receiver just skips ahead to the next status.
+                    Err(StatusesError::NoMoreStatuses) => break,
+                    Err(_) => continue,
                 }
             }
         });

--- a/replicant-client/tests/ffi_integration_tests.rs
+++ b/replicant-client/tests/ffi_integration_tests.rs
@@ -204,6 +204,7 @@ unsafe fn create_test_engine() -> *mut Replicant {
         email.as_ptr(),
         api_key.as_ptr(),
         api_secret.as_ptr(),
+        std::ptr::null(),
     )
 }
 


### PR DESCRIPTION
Client side of device enrollment. Replaces the single shared API key/secret compiled into every consumer with a per-user credential obtained by claiming a one-time code emailed by the server.

Stacked on `adam/identity-redesign-client` (PR #37) — this branch contains those commits, so review this diff against that base. It pairs with the server-side enrollment tokens/mailer in replicant-server#6.

## What's here

- **Encrypted-at-rest credential store** (`secret_store.rs`) — persists the per-user credential in the client data dir.
- **Enrollment HTTP** (`enrollment.rs`) — `request_enrollment` (server emails a code) and `claim_enrollment` (exchange code → credential). Request is retriable so hosts can offer a resend.
- **FFI + C++ surface** — `replicant_request_enrollment` / `replicant_claim_enrollment` / `replicant_{load,store,clear}_credentials` over the C ABI, plus the `replicant::Credentials` struct and free functions in `replicant.hpp`.
- **Join no longer asserts a user_id** — the client adopts the server-returned canonical id.
- **Rejoin fix** — reconnect with a fresh timestamp on channel rejoin.

## Why this is blocking

Consumers are already merged against this API and cannot build without it:

- entonal-common `main` (`aa21b78`) calls `replicant::Credentials`, `load_credentials`, `request_enrollment`, `clear_credentials` and `Client::get_user_id`.
- The latest published release is **v0.2.0 (April)**, which has none of it — not even the envelope-attribution `get_user_id` that merged to `main` in #36 but was never tagged.

So Entonal Studio CI compiles the new code against the v0.2.0 header and fails on every one of these symbols (Windows surfaced it first; macOS runners were masked by a local checkout).

**After merge, a tagged release with prebuilt libs is required** — the consumer pin (`entonal-common/database/CMakeLists.txt`, `fetch_replicant(VERSION 0.2.0)`) can only be bumped once release assets exist.